### PR TITLE
모든 사이트 조회하기 api 및 발급된 메타태그 정보 조회 api

### DIFF
--- a/src/main/java/com/pickax/status/page/server/controller/SiteController.java
+++ b/src/main/java/com/pickax/status/page/server/controller/SiteController.java
@@ -2,6 +2,12 @@ package com.pickax.status.page.server.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import com.pickax.status.page.server.dto.reseponse.DefaultSite;
+import com.pickax.status.page.server.dto.reseponse.MetaTagValidation;
 import org.springframework.web.bind.annotation.*;
 
 import com.pickax.status.page.server.dto.request.SiteCreateRequestDto;
@@ -12,6 +18,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 import java.io.IOException;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,4 +41,18 @@ public class SiteController {
 	public void verifySite(@PathVariable long siteId) throws IOException {
 		siteService.verifySite(siteId);
 	}
+
+	@GetMapping
+	public ResponseEntity<List<DefaultSite>> sitesByUserId() {
+		// 로그인 기능이 없으므로 임시로 생성
+		Long loggedInUserId = 1L;
+
+		return ResponseEntity.ok(this.siteService.findAllByUserId(loggedInUserId));
+	}
+
+	@GetMapping("/{siteId}/meta-tags")
+	public ResponseEntity<MetaTagValidation> validateByMetaTag(@PathVariable Long siteId) {
+		return ResponseEntity.ok(this.siteService.findValidMetaTag(siteId));
+	}
+
 }

--- a/src/main/java/com/pickax/status/page/server/domain/model/Site.java
+++ b/src/main/java/com/pickax/status/page/server/domain/model/Site.java
@@ -17,6 +17,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -46,6 +47,10 @@ public class Site {
 	@OneToMany(mappedBy = "site", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
 	private List<MetaTag> mataTags = new ArrayList<>();
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
 	public void addMetaTag(MetaTag metaTag) {
 		this.mataTags.add(metaTag);
 		metaTag.updateSite(this);
@@ -68,5 +73,9 @@ public class Site {
 
 	public void complete() {
 		this.siteRegistrationStatus = SiteRegistrationStatus.COMPLETED;
+	}
+
+	public boolean hasValidatedOwnerByMetaTag() {
+		return SiteRegistrationStatus.COMPLETED.equals(this.siteRegistrationStatus);
 	}
 }

--- a/src/main/java/com/pickax/status/page/server/domain/model/User.java
+++ b/src/main/java/com/pickax/status/page/server/domain/model/User.java
@@ -1,0 +1,16 @@
+package com.pickax.status.page.server.domain.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+}

--- a/src/main/java/com/pickax/status/page/server/dto/reseponse/DefaultSite.java
+++ b/src/main/java/com/pickax/status/page/server/dto/reseponse/DefaultSite.java
@@ -1,0 +1,23 @@
+package com.pickax.status.page.server.dto.reseponse;
+
+import com.pickax.status.page.server.domain.enumclass.SiteRegistrationStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DefaultSite {
+
+    private Long id;
+
+    private String name;
+
+    private String url;
+
+    private SiteRegistrationStatus ownerProofStatus;
+
+}

--- a/src/main/java/com/pickax/status/page/server/dto/reseponse/MetaTagValidation.java
+++ b/src/main/java/com/pickax/status/page/server/dto/reseponse/MetaTagValidation.java
@@ -1,0 +1,18 @@
+package com.pickax.status.page.server.dto.reseponse;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MetaTagValidation {
+
+    private Long id;
+
+    private String content;
+
+    public MetaTagValidation(Long id, String content) {
+        this.id = id;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/pickax/status/page/server/repository/MetaTagRepository.java
+++ b/src/main/java/com/pickax/status/page/server/repository/MetaTagRepository.java
@@ -3,9 +3,16 @@ package com.pickax.status.page.server.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.pickax.status.page.server.domain.model.MetaTag;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 import java.util.Optional;
 
 public interface MetaTagRepository extends JpaRepository<MetaTag, Long> {
-    Optional<MetaTag> findFirstBySite_Id(long id);
+
+    @Query("SELECT t FROM MetaTag t WHERE t.site.id = :siteId AND t.isChecked = :notChecked ORDER BY t.expiredDate DESC")
+    List<MetaTag> findMetaTagNotYetCheckedBySiteId(Long siteId, boolean notChecked);
+
+	Optional<MetaTag> findFirstBySite_Id(long id);
 }

--- a/src/main/java/com/pickax/status/page/server/repository/SiteRepository.java
+++ b/src/main/java/com/pickax/status/page/server/repository/SiteRepository.java
@@ -3,7 +3,9 @@ package com.pickax.status.page.server.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.pickax.status.page.server.domain.model.Site;
+import java.util.List;
 
 public interface SiteRepository extends JpaRepository<Site, Long> {
 
+    List<Site> findAllByUserId(Long loggedInUserId);
 }


### PR DESCRIPTION
추가해야 할 로직
- 메타 태그가 존재하지 않는 경우 현재는 에러를 발생시켜 처리하고 있으나 빈값을 내려줘서 메타태그를 재발급 할 수 있도록 처리해야 함
