### PR TITLE
feat : component list 조회 api 구현 및 테스트코드 sql 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,32 @@ dependencies {
 
     // parser
     implementation 'org.jsoup:jsoup:1.17.2'
+
+    // Query DSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+/**
+ * QueryDsl Configuration
+ */
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets {
+    main.java.srcDir querydslDir
+}
+
+tasks.withType(JavaCompile) {
+    options.generatedSourceOutputDirectory = file(querydslDir)
+}
+
+clean {
+    delete file(querydslDir)
 }

--- a/src/main/java/com/pickax/status/page/server/config/JpaConfig.java
+++ b/src/main/java/com/pickax/status/page/server/config/JpaConfig.java
@@ -1,0 +1,23 @@
+package com.pickax.status.page.server.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+
+@Configuration
+public class JpaConfig {
+
+	private final EntityManager entityManager;
+
+	public JpaConfig(EntityManager entityManager) {
+		this.entityManager = entityManager;
+	}
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/src/main/java/com/pickax/status/page/server/controller/ComponentController.java
+++ b/src/main/java/com/pickax/status/page/server/controller/ComponentController.java
@@ -1,8 +1,17 @@
 package com.pickax.status.page.server.controller;
 
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.pickax.status.page.server.dto.reseponse.ComponentResponseDto;
+import com.pickax.status.page.server.dto.reseponse.DefaultSite;
+import com.pickax.status.page.server.service.ComponentService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -11,4 +20,10 @@ import lombok.RequiredArgsConstructor;
 @Validated
 @RequestMapping("/sites")
 public class ComponentController {
+	private final ComponentService componentService;
+
+	@GetMapping("/{siteId}/components")
+	public ResponseEntity<List<ComponentResponseDto>> getComponents(@PathVariable Long siteId) {
+		return ResponseEntity.ok(componentService.getComponents(siteId));
+	}
 }

--- a/src/main/java/com/pickax/status/page/server/controller/ComponentController.java
+++ b/src/main/java/com/pickax/status/page/server/controller/ComponentController.java
@@ -9,8 +9,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.pickax.status.page.server.dto.reseponse.ComponentListResponseDto;
 import com.pickax.status.page.server.dto.reseponse.ComponentResponseDto;
-import com.pickax.status.page.server.dto.reseponse.DefaultSite;
 import com.pickax.status.page.server.service.ComponentService;
 
 import lombok.RequiredArgsConstructor;
@@ -22,8 +22,10 @@ import lombok.RequiredArgsConstructor;
 public class ComponentController {
 	private final ComponentService componentService;
 
-	@GetMapping("/{siteId}/components")
-	public ResponseEntity<List<ComponentResponseDto>> getComponents(@PathVariable Long siteId) {
-		return ResponseEntity.ok(componentService.getComponents(siteId));
+	@GetMapping("/{siteId}/components/active")
+	public ResponseEntity<ComponentListResponseDto> getActiveComponents(@PathVariable Long siteId) {
+		List<ComponentResponseDto> components = componentService.getActiveComponents(siteId);
+		ComponentListResponseDto componentListResponseDto = new ComponentListResponseDto(components);
+		return ResponseEntity.ok(componentListResponseDto);
 	}
 }

--- a/src/main/java/com/pickax/status/page/server/domain/enumclass/ComponentStatus.java
+++ b/src/main/java/com/pickax/status/page/server/domain/enumclass/ComponentStatus.java
@@ -2,5 +2,6 @@ package com.pickax.status.page.server.domain.enumclass;
 
 public enum ComponentStatus {
 	// 임시
-	WARN
+	WARN,
+	NONE
 }

--- a/src/main/java/com/pickax/status/page/server/dto/reseponse/ComponentListResponseDto.java
+++ b/src/main/java/com/pickax/status/page/server/dto/reseponse/ComponentListResponseDto.java
@@ -1,0 +1,17 @@
+package com.pickax.status.page.server.dto.reseponse;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class ComponentListResponseDto {
+
+	private List<ComponentResponseDto> componentResponseDtoList;
+
+	public ComponentListResponseDto(List<ComponentResponseDto> componentResponseDtoList) {
+		this.componentResponseDtoList = componentResponseDtoList;
+	}
+}

--- a/src/main/java/com/pickax/status/page/server/dto/reseponse/ComponentResponseDto.java
+++ b/src/main/java/com/pickax/status/page/server/dto/reseponse/ComponentResponseDto.java
@@ -1,0 +1,26 @@
+package com.pickax.status.page.server.dto.reseponse;
+
+import com.pickax.status.page.server.domain.enumclass.ComponentStatus;
+import com.querydsl.core.annotations.QueryProjection;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ComponentResponseDto {
+	private Long id;
+	private String name;
+	private String description;
+	private ComponentStatus status;
+
+	@QueryProjection
+	public ComponentResponseDto(
+		Long id, String name, String description, ComponentStatus status
+	) {
+		this.id = id;
+		this.name = name;
+		this.description = description;
+		this.status = status;
+	}
+}

--- a/src/main/java/com/pickax/status/page/server/repository/ComponentRepository.java
+++ b/src/main/java/com/pickax/status/page/server/repository/ComponentRepository.java
@@ -4,5 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.pickax.status.page.server.domain.model.Component;
 
-public interface ComponentRepository extends JpaRepository<Component, Long> {
+public interface ComponentRepository extends JpaRepository<Component, Long>, ComponentRepositoryCustom {
+
 }

--- a/src/main/java/com/pickax/status/page/server/repository/ComponentRepositoryCustom.java
+++ b/src/main/java/com/pickax/status/page/server/repository/ComponentRepositoryCustom.java
@@ -5,5 +5,5 @@ import java.util.List;
 import com.pickax.status.page.server.dto.reseponse.ComponentResponseDto;
 
 public interface ComponentRepositoryCustom {
-	List<ComponentResponseDto> getComponents(Long siteId);
+	List<ComponentResponseDto> getComponents(Long siteId, boolean isActive);
 }

--- a/src/main/java/com/pickax/status/page/server/repository/ComponentRepositoryCustom.java
+++ b/src/main/java/com/pickax/status/page/server/repository/ComponentRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.pickax.status.page.server.repository;
+
+import java.util.List;
+
+import com.pickax.status.page.server.dto.reseponse.ComponentResponseDto;
+
+public interface ComponentRepositoryCustom {
+	List<ComponentResponseDto> getComponents(Long siteId);
+}

--- a/src/main/java/com/pickax/status/page/server/repository/ComponentRepositoryImpl.java
+++ b/src/main/java/com/pickax/status/page/server/repository/ComponentRepositoryImpl.java
@@ -18,7 +18,7 @@ public class ComponentRepositoryImpl implements ComponentRepositoryCustom {
 	private final JPAQueryFactory queryFactory;
 
 	@Override
-	public List<ComponentResponseDto> getComponents(Long siteId) {
+	public List<ComponentResponseDto> getComponents(Long siteId, boolean isActive) {
 		return queryFactory
 			.select(new QComponentResponseDto(
 				component.id,
@@ -30,7 +30,7 @@ public class ComponentRepositoryImpl implements ComponentRepositoryCustom {
 			.from(component)
 			.where(
 				component.site.id.eq(siteId),
-				component.isActive.eq(true)
+				component.isActive.eq(isActive)
 			)
 			.fetch();
 	}

--- a/src/main/java/com/pickax/status/page/server/repository/ComponentRepositoryImpl.java
+++ b/src/main/java/com/pickax/status/page/server/repository/ComponentRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.pickax.status.page.server.repository;
+
+import static com.pickax.status.page.server.domain.model.QComponent.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.pickax.status.page.server.dto.reseponse.ComponentResponseDto;
+import com.pickax.status.page.server.dto.reseponse.QComponentResponseDto;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ComponentRepositoryImpl implements ComponentRepositoryCustom {
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<ComponentResponseDto> getComponents(Long siteId) {
+		return queryFactory
+			.select(new QComponentResponseDto(
+				component.id,
+				component.name,
+				component.description,
+				component.componentStatus
+			)
+			)
+			.from(component)
+			.where(
+				component.site.id.eq(siteId),
+				component.isActive.eq(true)
+			)
+			.fetch();
+	}
+}

--- a/src/main/java/com/pickax/status/page/server/service/ComponentService.java
+++ b/src/main/java/com/pickax/status/page/server/service/ComponentService.java
@@ -2,10 +2,8 @@ package com.pickax.status.page.server.service;
 
 import java.util.List;
 
-import org.springframework.data.crossstore.ChangeSetPersister;
 import org.springframework.stereotype.Service;
 
-import com.pickax.status.page.server.domain.model.Site;
 import com.pickax.status.page.server.dto.reseponse.ComponentResponseDto;
 import com.pickax.status.page.server.repository.ComponentRepository;
 import com.pickax.status.page.server.repository.SiteRepository;
@@ -19,8 +17,8 @@ public class ComponentService {
 	private final ComponentRepository componentRepository;
 	private final SiteRepository siteRepository;
 
-	public List<ComponentResponseDto> getComponents(Long siteId) {
+	public List<ComponentResponseDto> getActiveComponents(Long siteId) {
 		siteRepository.findById(siteId).orElseThrow(EntityNotFoundException::new);
-		return componentRepository.getComponents(siteId);
+		return componentRepository.getComponents(siteId, true);
 	}
 }

--- a/src/main/java/com/pickax/status/page/server/service/ComponentService.java
+++ b/src/main/java/com/pickax/status/page/server/service/ComponentService.java
@@ -1,10 +1,26 @@
 package com.pickax.status.page.server.service;
 
+import java.util.List;
+
+import org.springframework.data.crossstore.ChangeSetPersister;
 import org.springframework.stereotype.Service;
 
+import com.pickax.status.page.server.domain.model.Site;
+import com.pickax.status.page.server.dto.reseponse.ComponentResponseDto;
+import com.pickax.status.page.server.repository.ComponentRepository;
+import com.pickax.status.page.server.repository.SiteRepository;
+
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class ComponentService {
+	private final ComponentRepository componentRepository;
+	private final SiteRepository siteRepository;
+
+	public List<ComponentResponseDto> getComponents(Long siteId) {
+		siteRepository.findById(siteId).orElseThrow(EntityNotFoundException::new);
+		return componentRepository.getComponents(siteId);
+	}
 }

--- a/src/test/java/com/pickax/status/page/server/controller/ComponentControllerTest.java
+++ b/src/test/java/com/pickax/status/page/server/controller/ComponentControllerTest.java
@@ -1,0 +1,51 @@
+package com.pickax.status.page.server.controller;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@ActiveProfiles("test")
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@Sql(scripts = {
+	"classpath:data/users.sql",
+	"classpath:data/sites.sql",
+	"classpath:data/components.sql"})
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ComponentControllerTest {
+	@Autowired
+	public MockMvc mockMvc;
+
+	@Test
+	@DisplayName("GET Component 리스트 조회 api - 200 OK")
+	void getComponents() throws Exception {
+		// when
+		Long siteId = 1L;
+		String url = String.format("/sites/%s/components", siteId);
+
+		mockMvc.perform(
+				MockMvcRequestBuilders
+					.get(url)
+					.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+
+			// then
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.size()").value("2"));
+	}
+}

--- a/src/test/java/com/pickax/status/page/server/controller/ComponentControllerTest.java
+++ b/src/test/java/com/pickax/status/page/server/controller/ComponentControllerTest.java
@@ -35,7 +35,7 @@ class ComponentControllerTest {
 	void getComponents() throws Exception {
 		// when
 		Long siteId = 1L;
-		String url = String.format("/sites/%s/components", siteId);
+		String url = String.format("/sites/%s/components/active", siteId);
 
 		mockMvc.perform(
 				MockMvcRequestBuilders
@@ -46,6 +46,6 @@ class ComponentControllerTest {
 
 			// then
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.size()").value("2"));
+			.andExpect(jsonPath("$.componentResponseDtoList.size()").value("2"));
 	}
 }

--- a/src/test/resources/data/components.sql
+++ b/src/test/resources/data/components.sql
@@ -1,0 +1,3 @@
+insert into components(id, name, description, component_status, frequency, is_active, site_id)
+values (1, '1 name', '1 description', 'NONE', 5, true, 1),
+       (2, '2 name', '2 description', 'NONE', 5, true, 1);

--- a/src/test/resources/data/sites.sql
+++ b/src/test/resources/data/sites.sql
@@ -1,0 +1,3 @@
+insert into sites(id, name, description, url, site_registration_status, user_id)
+values (1, '1 name', '1 description', 'http://dasfas', 'COMPLETED', 1),
+       (2, '2 name', '2 description', 'http://dqdwqdw', 'COMPLETED', 2);

--- a/src/test/resources/data/users.sql
+++ b/src/test/resources/data/users.sql
@@ -1,0 +1,3 @@
+insert into users(id)
+values (1),
+       (2);


### PR DESCRIPTION
## component list 조회 api 구현 및 테스트코드 sql 추가

- 특정 siteId에 component 리스트 조회
  - active 상태인 값만 조회
- 테스트코드를 위한 sql 작성
- QueryDSL 의존성 추가