### PR TITLE
fix: 컴포넌트 등록 시 사이트 소유자 검사 주석 처리

### DIFF
--- a/src/main/java/com/pickax/status/page/server/service/ComponentService.java
+++ b/src/main/java/com/pickax/status/page/server/service/ComponentService.java
@@ -25,9 +25,10 @@ public class ComponentService {
     @Transactional
     public void createComponent(Long siteId, ComponentCreateRequestDto request, Long loggedInUserId) {
         Site site = this.siteRepository.findById(siteId).orElseThrow(() -> new EntityNotFoundException("존재하지 않는 사이트 입니다."));
-        if (!site.ownerEqualsBy(loggedInUserId)) {
-            throw new IllegalArgumentException("해당 사이트의 정당한 소유자가 아닙니다.");
-        }
+        // 로그인 기능이 생기기 전까지 주석처리 합니다.
+//        if (!site.ownerEqualsBy(loggedInUserId)) {
+//            throw new IllegalArgumentException("해당 사이트의 정당한 소유자가 아닙니다.");
+//        }
 
         Component component = Component.create(request.getName(),
                 request.getDescription(),


### PR DESCRIPTION
유저 관련 정보가 없으므로 사이트의 소유자가 맞는지 검사하는 로직을 주석 처리 하였습니다.
해당 로직은 로그인 기능을 만든 후 다시 주석 해제할 예정입니다.