### PR TITLE
fix: 컴포넌트 등록 시 isActive 타입을 Wrapper type 으로 변경

### DIFF
--- a/src/main/java/com/pickax/status/page/server/dto/request/ComponentCreateRequestDto.java
+++ b/src/main/java/com/pickax/status/page/server/dto/request/ComponentCreateRequestDto.java
@@ -18,6 +18,6 @@ public class ComponentCreateRequestDto {
     private Long frequency;
 
     @NotNull
-    private boolean isActive;
+    private Boolean isActive;
 
 }

--- a/src/main/java/com/pickax/status/page/server/service/ComponentService.java
+++ b/src/main/java/com/pickax/status/page/server/service/ComponentService.java
@@ -37,7 +37,7 @@ public class ComponentService {
                 request.getDescription(),
                 ComponentStatus.NONE,
                 request.getFrequency(),
-                request.isActive(),
+                request.getIsActive(),
                 site
         );
 


### PR DESCRIPTION
내용 
- request 를 dto로 바인딩 할때 primitive boolean type 의 변수명이 is로 시작되면 jackson 라이브러리에서 is 를 생략하므로 isActive 변수명이 의도한대로 바인딩 되지 않음 (isActive 를 true 로 보내도 false 로만 바인딩이 됨)
- primitive type 을 Wrapper type 으로 수정
