### PR TITLE
feat: 컴포넌트 상태의 마지막 업데이트 시간 반환

### DIFF
--- a/src/main/java/com/pickax/status/page/server/config/SpringQuartzSchedulerConfig.java
+++ b/src/main/java/com/pickax/status/page/server/config/SpringQuartzSchedulerConfig.java
@@ -14,7 +14,6 @@ import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.scheduling.quartz.JobDetailFactoryBean;
 import org.springframework.scheduling.quartz.SchedulerFactoryBean;
 import org.springframework.scheduling.quartz.SimpleTriggerFactoryBean;
@@ -83,10 +82,6 @@ public class SpringQuartzSchedulerConfig {
     @Bean
     public SchedulerFactoryBean scheduler(Trigger trigger, JobDetail job, DataSource quartzDataSource) {
         SchedulerFactoryBean schedulerFactory = new SchedulerFactoryBean();
-        final String QUARTZ_CONFIG_PATH = "application.yml";
-
-        schedulerFactory.setConfigLocation(new ClassPathResource(QUARTZ_CONFIG_PATH));
-
         log.debug("Setting the Scheduler up");
         schedulerFactory.setJobFactory(springBeanJobFactory());
         schedulerFactory.setJobDetails(job);

--- a/src/main/java/com/pickax/status/page/server/controller/ComponentController.java
+++ b/src/main/java/com/pickax/status/page/server/controller/ComponentController.java
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.*;
 
 import com.pickax.status.page.server.dto.reseponse.component.ComponentActiveListResponseDto;
-import com.pickax.status.page.server.dto.reseponse.component.ComponentActiveResponseDto;
 
 import lombok.RequiredArgsConstructor;
 
@@ -36,9 +35,7 @@ public class ComponentController {
 
 	@GetMapping("/{siteId}/components/active")
 	public ResponseEntity<ComponentActiveListResponseDto> getActiveComponents(@PathVariable Long siteId) {
-		List<ComponentActiveResponseDto> components = componentService.getActiveComponents(siteId);
-		ComponentActiveListResponseDto componentActiveListResponseDto = new ComponentActiveListResponseDto(components);
-		return ResponseEntity.ok(componentActiveListResponseDto);
+		return ResponseEntity.ok(componentService.getActiveComponents(siteId));
 	}
 
 	@GetMapping("/{siteId}/components")

--- a/src/main/java/com/pickax/status/page/server/domain/model/Component.java
+++ b/src/main/java/com/pickax/status/page/server/domain/model/Component.java
@@ -17,6 +17,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Table(name = "components")
@@ -46,6 +48,9 @@ public class Component {
 	@JoinColumn(name = "site_id")
 	private Site site;
 
+	@Column(name = "last_updated_at")
+	private LocalDateTime lastUpdatedDate;
+
 	private Component(String name, String description, ComponentStatus status, Long frequency, boolean isActive, Site site) {
 		this.name = name;
 		this.description = description;
@@ -58,5 +63,4 @@ public class Component {
 	public static Component create(String name, String description, ComponentStatus status, Long frequency, boolean isActive, Site site) {
 		return new Component(name, description, status, frequency, isActive, site);
 	}
-
 }

--- a/src/main/java/com/pickax/status/page/server/dto/reseponse/component/ComponentActiveListResponseDto.java
+++ b/src/main/java/com/pickax/status/page/server/dto/reseponse/component/ComponentActiveListResponseDto.java
@@ -1,5 +1,6 @@
 package com.pickax.status.page.server.dto.reseponse.component;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import lombok.Getter;
@@ -11,7 +12,14 @@ public class ComponentActiveListResponseDto {
 
 	private List<ComponentActiveResponseDto> componentActiveResponseDtoList;
 
-	public ComponentActiveListResponseDto(List<ComponentActiveResponseDto> componentActiveResponseDtoList) {
+	private LocalDateTime lastUpdatedDate;
+
+	private ComponentActiveListResponseDto(List<ComponentActiveResponseDto> componentActiveResponseDtoList, LocalDateTime lastUpdatedDate) {
 		this.componentActiveResponseDtoList = componentActiveResponseDtoList;
+		this.lastUpdatedDate = lastUpdatedDate;
+	}
+
+	public static ComponentActiveListResponseDto of(List<ComponentActiveResponseDto> componentActiveResponses, LocalDateTime lastUpdatedDate) {
+		return new ComponentActiveListResponseDto(componentActiveResponses, lastUpdatedDate);
 	}
 }

--- a/src/main/java/com/pickax/status/page/server/dto/reseponse/component/ComponentActiveResponseDto.java
+++ b/src/main/java/com/pickax/status/page/server/dto/reseponse/component/ComponentActiveResponseDto.java
@@ -6,6 +6,8 @@ import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Getter
 @NoArgsConstructor
 public class ComponentActiveResponseDto {
@@ -13,14 +15,16 @@ public class ComponentActiveResponseDto {
 	private String name;
 	private String description;
 	private ComponentStatus status;
+	private LocalDateTime lastUpdatedDate;
 
 	@QueryProjection
 	public ComponentActiveResponseDto(
-		Long id, String name, String description, ComponentStatus status
+		Long id, String name, String description, ComponentStatus status, LocalDateTime lastUpdatedDate
 	) {
 		this.id = id;
 		this.name = name;
 		this.description = description;
 		this.status = status;
+		this.lastUpdatedDate = lastUpdatedDate;
 	}
 }

--- a/src/main/java/com/pickax/status/page/server/repository/ComponentRepositoryCustom.java
+++ b/src/main/java/com/pickax/status/page/server/repository/ComponentRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.pickax.status.page.server.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -13,7 +14,7 @@ public interface ComponentRepositoryCustom {
 
 	List<ComponentResponseDto> getComponentResponses(Long siteId);
 
-	void updateComponentStatus(Long componentId, ComponentStatus componentStatus);
+	void updateComponentStatus(Long componentId, ComponentStatus componentStatus, LocalDateTime lastUpdatedDate);
 
 	Optional<Component> getComponent(Long id);
 }

--- a/src/main/java/com/pickax/status/page/server/repository/ComponentRepositoryImpl.java
+++ b/src/main/java/com/pickax/status/page/server/repository/ComponentRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.pickax.status.page.server.repository;
 import static com.pickax.status.page.server.domain.model.QComponent.*;
 import static com.pickax.status.page.server.domain.model.QSite.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -30,9 +31,9 @@ public class ComponentRepositoryImpl implements ComponentRepositoryCustom {
 				component.id,
 				component.name,
 				component.description,
-				component.componentStatus
-			)
-			)
+				component.componentStatus,
+                component.lastUpdatedDate
+			))
 			.from(component)
 			.where(
 				component.site.id.eq(siteId),
@@ -71,10 +72,11 @@ public class ComponentRepositoryImpl implements ComponentRepositoryCustom {
     }
 
 	@Override
-	public void updateComponentStatus(Long componentId, ComponentStatus componentStatus) {
+	public void updateComponentStatus(Long componentId, ComponentStatus componentStatus, LocalDateTime lastUpdatedDate) {
 		queryFactory
 				.update(component)
 				.set(component.componentStatus, componentStatus)
+				.set(component.lastUpdatedDate, lastUpdatedDate)
 				.where(component.id.eq(componentId))
 				.execute();
 	}

--- a/src/main/java/com/pickax/status/page/server/scheduler/ComponentStatusLogJob.java
+++ b/src/main/java/com/pickax/status/page/server/scheduler/ComponentStatusLogJob.java
@@ -4,7 +4,6 @@ import com.pickax.status.page.server.service.ComponentStatusLogService;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -16,7 +15,7 @@ public class ComponentStatusLogJob implements Job {
     private ComponentStatusLogService componentStatusLogService;
 
     @Override
-    public void execute(JobExecutionContext context) throws JobExecutionException {
+    public void execute(JobExecutionContext context) {
         log.debug("status log job execute");
         this.componentStatusLogService.inspectHealthCheckCall();
     }

--- a/src/test/java/com/pickax/status/page/server/controller/ComponentControllerTest.java
+++ b/src/test/java/com/pickax/status/page/server/controller/ComponentControllerTest.java
@@ -47,7 +47,8 @@ class ComponentControllerTest {
 
 			// then
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.componentActiveResponseDtoList.size()").value("1"));
+			.andExpect(jsonPath("$.componentActiveResponseDtoList.size()").value("5"))
+			.andExpect(jsonPath("$.lastUpdatedDate").value("2022-12-08T11:44:30.327959"));
 	}
 
 	@Test
@@ -85,7 +86,7 @@ class ComponentControllerTest {
 
 			// then
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.componentResponseDtoList.size()").value("2"));
+			.andExpect(jsonPath("$.componentResponseDtoList.size()").value("6"));
 	}
 
 	@Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,14 +1,30 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:status_page;MODE=MySQL;DATABASE_TO_LOWER=TRUE
     driver-class-name: org.h2.Driver
+    jdbc-url: jdbc:h2:mem:status_page;MODE=MySQL;DATABASE_TO_LOWER=TRUE
     username: sa
     password:
   h2:
     console:
       enabled: true
+  quartz:
+    job-store-type: jdbc
+    scheduler-name: QuackScheduler
+    jdbc:
+      initialize-schema: always
+    properties:
+      org:
+        quartz:
+          threadPool:
+            class: org.quartz.simpl.SimpleThreadPool
+            threadsInheritContextClassLoaderOfInitializingThread: true
+          jobStore:
+            class: org.quartz.impl.jdbcjobstore.JobStoreTX
+            driverDelegateClass: org.quartz.impl.jdbcjobstore.StdJDBCDelegate
 
   jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    defer-datasource-initialization: true
     hibernate:
       ddl-auto: create
     properties:

--- a/src/test/resources/data/components.sql
+++ b/src/test/resources/data/components.sql
@@ -4,6 +4,10 @@ truncate table `components`;
 set
     FOREIGN_KEY_CHECKS = 1;
 
-insert into components(id, name, description, component_status, frequency, is_active, site_id)
-values (1, '1 name', '1 description', 'NONE', 5, true, 1),
-       (2, '2 name', '2 description', 'NONE', 5, false, 1);
+insert into components(id, name, description, component_status, frequency, is_active, site_id, last_updated_at)
+values (1, '1 name', '1 description', 'NONE', 5, true, 1, null),
+       (2, '2 name', '2 description', 'NONE', 5, false, 1, null),
+       (3, '3 name', '3 description', 'NONE', 5, true, 1, '2020-12-08T11:44:30.327959'),
+       (4, '4 name', '4 description', 'NONE', 5, true, 1, '2020-11-08T11:44:30.327959'),
+       (5, '5 name', '5 description', 'NONE', 5, true, 1, '2022-12-08T11:44:30.327959'),
+       (6, '6 name', '6 description', 'NONE', 5, true, 1, '2021-11-08T11:44:30.327959');


### PR DESCRIPTION
컴포넌트 상태의 마지막 업데이트 시간 반환
- 컴포넌트 상태의 마지막 업데이트 시간을 저장하기 위해 엔티티 필드 추가
- 컴포넌트 리스트 중 lastUpdatedDate 를 가져오는 기준
     - 해당 컴포넌트의 lastUpdatedDate 이 null 이 아닌 경우
     - 컴포넌트들 중 상태 변경 시간이 가장 최근인 것
- 테스트 코드 실행에서 에러가 발생했던 원인이 확인되어 수정해주는 작업도 살포시 끼워넣었습니다,,
     - 원인 
          - 테스트 설정 파일에 쿼츠 스케줄러 관련 설정 누락
          - 스케줄러 설정 클래스에(SpringQuartzSchedulerConfig) sheduler 빈으로 등록하는 메소드에 설정 파일 경로가 스태틱하게 박혀있어서 테스트 설정을 못읽어 오고 application.yml 경로의 파일을 읽어오는 문제 (이미지 참고)          
![image](https://github.com/pickax-developer/status-page-server/assets/68418154/a7d572d0-e612-438c-a831-819129816e84)
