### PR TITLE
feat: 에러 로그 슬랙 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,22 +59,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
 
-    // java mail sender
-    implementation 'org.springframework.boot:spring-boot-starter-mail'
-
-    // thymeleaf
-    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-
     // jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
 
-    // java mail sender
-    implementation 'org.springframework.boot:spring-boot-starter-mail'
-
-    // thymeleaf
-    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    // slack
+    implementation 'com.slack.api:slack-api-client:1.25.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/pickax/status/page/server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/pickax/status/page/server/common/exception/GlobalExceptionHandler.java
@@ -2,37 +2,53 @@ package com.pickax.status.page.server.common.exception;
 
 import com.pickax.status.page.server.common.message.LocaleMessageConverter;
 import com.pickax.status.page.server.dto.reseponse.common.ErrorResponse;
+import com.pickax.status.page.server.service.slack.SlackService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
 
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class GlobalExceptionHandler {
 
 	private final LocaleMessageConverter localeMessage;
+	private final SlackService slackService;
 
 	@ExceptionHandler(value = {CustomException.class})
 	protected ResponseEntity<ErrorResponse> handleCustomException(CustomException e, HttpServletRequest request) {
+		sendErrorMessageToSlack(e, localeMessage.getMessage(e.getErrorCode().toString()), e.getErrorCode().getHttpStatus());
 		return ErrorResponse.toResponseEntity(e.getErrorCode(), localeMessage.getMessage(e.getErrorCode().toString()), request);
 	}
 
 	@ExceptionHandler(ConstraintViolationException.class)
 	protected ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException e, HttpServletRequest request) {
+		sendErrorMessageToSlack(e, localeMessage.getMessage(ErrorCode.INVALID_INPUT_VALUE.toString()), HttpStatus.BAD_REQUEST);
 		return ErrorResponse.toResponseEntity(ErrorCode.INVALID_INPUT_VALUE, localeMessage.getMessage(ErrorCode.INVALID_INPUT_VALUE.toString()), request);
 	}
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e, HttpServletRequest request) {
-		return ErrorResponse.toResponseEntity(ErrorCode.INVALID_INPUT_VALUE, e.getBindingResult(), request);
+		List<FieldError> fieldErrors =  e.getBindingResult().getFieldErrors();
+		String message = fieldErrors.get(0) == null ? "" : fieldErrors.get(0).getDefaultMessage();
+		sendErrorMessageToSlack(e, message, HttpStatus.BAD_REQUEST);
+		return ErrorResponse.toResponseEntity(ErrorCode.INVALID_INPUT_VALUE, message, fieldErrors, request);
 	}
 
 	@ExceptionHandler(Exception.class)
 	protected ResponseEntity<ErrorResponse> handleException(Exception e, HttpServletRequest request) {
+		sendErrorMessageToSlack(e, e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
 		return ErrorResponse.toResponseEntity(ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage(), request);
+	}
+
+	private void sendErrorMessageToSlack(Exception e, String message, HttpStatus httpStatus) {
+		slackService.sendErrorMessage(e, message, httpStatus);
 	}
 }

--- a/src/main/java/com/pickax/status/page/server/dto/reseponse/common/ErrorResponse.java
+++ b/src/main/java/com/pickax/status/page/server/dto/reseponse/common/ErrorResponse.java
@@ -52,10 +52,8 @@ public class ErrorResponse {
     }
 
     public static ResponseEntity<ErrorResponse> toResponseEntity(
-            ErrorCode errorCode, final BindingResult bindingResult, HttpServletRequest request
+            ErrorCode errorCode, final String message, List<FieldError> fieldErrors, HttpServletRequest request
     ) {
-        final List<FieldError> fieldErrors = bindingResult.getFieldErrors();
-        String message = fieldErrors.get(0) == null ? "" : fieldErrors.get(0).getDefaultMessage();
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(ErrorResponse.builder()

--- a/src/main/java/com/pickax/status/page/server/service/slack/SlackService.java
+++ b/src/main/java/com/pickax/status/page/server/service/slack/SlackService.java
@@ -1,0 +1,47 @@
+package com.pickax.status.page.server.service.slack;
+
+import com.slack.api.Slack;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.model.Attachment;
+import com.slack.api.model.block.LayoutBlock;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@Service
+public class SlackService {
+    @Value(value = "${spring.profiles.active}")
+    String profile;
+
+    @Value(value = "${slack.token}")
+    String token;
+
+    @Value(value = "${slack.channel.monitor}")
+    String channel;
+
+    private static final String PROD = "prod";
+    private static final String PROD_ERROR_MESSAGE_TITLE = "🐤 *꽤액!!! 꽤애액!!! 에러 발생!!!*";
+    private static final String CLIENT_5xx_ERROR_COLOR = "#e82415";
+    private static final String CLIENT_4xx_ERROR_COLOR = "#e8bf1a";
+
+    public void sendErrorMessage(Exception exception, String message, HttpStatus httpStatus) {
+        if (PROD.equals(profile)) {
+            try {
+                String color = httpStatus.is4xxClientError() ? CLIENT_4xx_ERROR_COLOR : CLIENT_5xx_ERROR_COLOR;
+                List<LayoutBlock> layoutBlocks = SlackServiceUtils.createErrorMessage(exception, message);
+                List<Attachment> attachments = SlackServiceUtils.createAttachments(color, layoutBlocks);
+                Slack.getInstance().methods(token).chatPostMessage(request ->
+                        request.channel(channel)
+                                .attachments(attachments)
+                                .text(PROD_ERROR_MESSAGE_TITLE));
+            } catch (SlackApiException | IOException e) {
+                log.error(e.getMessage(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/pickax/status/page/server/service/slack/SlackServiceUtils.java
+++ b/src/main/java/com/pickax/status/page/server/service/slack/SlackServiceUtils.java
@@ -1,0 +1,52 @@
+package com.pickax.status.page.server.service.slack;
+
+import com.slack.api.model.Attachment;
+import com.slack.api.model.block.LayoutBlock;
+import com.slack.api.model.block.composition.TextObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.slack.api.model.block.Blocks.divider;
+import static com.slack.api.model.block.Blocks.section;
+import static com.slack.api.model.block.composition.BlockCompositions.markdownText;
+
+public class SlackServiceUtils {
+    private static final String ERROR_MESSAGE = "*Error Message:*\n";
+    private static final String ERROR_STACK = "*Error Stack:*\n";
+    private static final String FILTER_STRING = "pickax";
+
+    public static List<Attachment> createAttachments(String color, List<LayoutBlock> data) {
+        List<Attachment> attachments = new ArrayList<>();
+        Attachment attachment = new Attachment();
+        attachment.setColor(color);
+        attachment.setBlocks(data);
+        attachments.add(attachment);
+        return attachments;
+    }
+
+    public static List<LayoutBlock> createErrorMessage(Exception exception, String message) {
+        List<LayoutBlock> layoutBlockList = new ArrayList<>();
+
+        List<TextObject> sectionInFields = new ArrayList<>();
+        sectionInFields.add(markdownText(ERROR_MESSAGE + message));
+        sectionInFields.add(markdownText(ERROR_STACK + exception));
+        layoutBlockList.add(section(section -> section.fields(sectionInFields)));
+
+        layoutBlockList.add(divider());
+        layoutBlockList.add(section(section -> section.text(markdownText(filterErrorStack(exception.getStackTrace())))));
+        return layoutBlockList;
+    }
+
+    private static String filterErrorStack(StackTraceElement[] stacks) {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("```");
+        for (StackTraceElement stack : stacks) {
+            if (stack.toString().contains(FILTER_STRING)) {
+                stringBuilder.append(stack).append("\n");
+            }
+        }
+        stringBuilder.append("```");
+        return stringBuilder.toString();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  profiles:
+    active: ${ACTIVE_PROFILE}
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     jdbc-url: ${DB_HOST}
@@ -54,3 +56,9 @@ security:
   jwt-config:
     secret: "&E)H@McQeThWmZq4t7w!z%C*F-JaNdRgUjXn2r5u8x/A?D(G+KbPeShVmYp3s6v9"
     access-token-expire: 3600000
+
+slack:
+  token: ${BOT_USER_OAUTH_TOKEN}
+  channel:
+    monitor: '#error-quack-run'
+


### PR DESCRIPTION
슬랙 채널에서 에러 로그에 대한 모니터링을 위해 연동
- 의존성이 중복으로 들어가 있는 것이 발견되어 삭제해주었습니다.
- 500대 에러뿐만 아니라 400대 에러로 모니터링 대상이 될 수 있게 구현하였습니다.
<img width="681" alt="스크린샷 2024-01-25 오후 7 28 07" src="https://github.com/pickax-developer/status-page-server/assets/68418154/5b6f9184-1cd4-436a-9417-7deb53c82136">
