### PR TITLE
feat: 컴포넌트 상태 변경 메일 알림 기능 구현

### DIFF
--- a/src/main/java/com/pickax/status/page/server/common/event/ComponentStatusInspectedEvent.java
+++ b/src/main/java/com/pickax/status/page/server/common/event/ComponentStatusInspectedEvent.java
@@ -1,0 +1,33 @@
+package com.pickax.status.page.server.common.event;
+
+import com.pickax.status.page.server.domain.enumclass.ComponentStatus;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ComponentStatusInspectedEvent {
+
+    private ComponentStatus previousComponentStatus;
+
+    private ComponentStatus currentComponentStatus;
+
+    private String siteName;
+
+    private String componentName;
+
+    private String username;
+
+    @Builder
+    public ComponentStatusInspectedEvent(
+            ComponentStatus previousComponentStatus, ComponentStatus currentComponentStatus, String siteName, String componentName, String username
+    ) {
+        this.previousComponentStatus = previousComponentStatus;
+        this.currentComponentStatus = currentComponentStatus;
+        this.siteName = siteName;
+        this.componentName = componentName;
+        this.username = username;
+    }
+
+}

--- a/src/main/java/com/pickax/status/page/server/common/event/handler/EmailEventHandler.java
+++ b/src/main/java/com/pickax/status/page/server/common/event/handler/EmailEventHandler.java
@@ -1,0 +1,22 @@
+package com.pickax.status.page.server.common.event.handler;
+
+import com.pickax.status.page.server.common.EmailSender;
+import com.pickax.status.page.server.common.event.ComponentStatusInspectedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EmailEventHandler {
+
+    private final EmailSender emailSender;
+
+    @EventListener
+    public void sendEmail(ComponentStatusInspectedEvent event) {
+        emailSender.sendComponentStatusChangedNotifyEmail(event);
+        log.debug("[{}-{}] 컴포넌트 상태 변경 메일 발송", event.getSiteName(), event.getComponentName());
+    }
+}

--- a/src/main/java/com/pickax/status/page/server/domain/model/Component.java
+++ b/src/main/java/com/pickax/status/page/server/domain/model/Component.java
@@ -59,4 +59,13 @@ public class Component {
 		return new Component(name, description, status, frequency, isActive, site);
 	}
 
+	public boolean hasToBeChangedStatus(ComponentStatus currentComponentStatus) {
+		return !this.componentStatus.equals(currentComponentStatus);
+	}
+
+	public void changedStatus(ComponentStatus currentComponentStatus) {
+		if (hasToBeChangedStatus(currentComponentStatus)) {
+			this.componentStatus = currentComponentStatus;
+		}
+	}
 }

--- a/src/main/java/com/pickax/status/page/server/dto/LatestHealthCheckCallLogDto.java
+++ b/src/main/java/com/pickax/status/page/server/dto/LatestHealthCheckCallLogDto.java
@@ -19,11 +19,19 @@ public class LatestHealthCheckCallLogDto {
 
     private Long frequency;
 
+    private String componentStatus;
 
-    public LatestHealthCheckCallLogDto(Long healthCheckCallLogId, Long componentId, Timestamp latestRequestDateTime, Long frequency) {
+    private String componentName;
+
+    private String siteName;
+
+    public LatestHealthCheckCallLogDto(Long healthCheckCallLogId, Long componentId, Timestamp latestRequestDateTime, Long frequency, String componentStatus, String componentName, String siteName) {
         this.healthCheckCallLogId = healthCheckCallLogId;
         this.componentId = componentId;
         this.latestRequestDateTime = latestRequestDateTime;
         this.frequency = frequency;
+        this.componentStatus = componentStatus;
+        this.componentName = componentName;
+        this.siteName = siteName;
     }
 }

--- a/src/main/java/com/pickax/status/page/server/repository/HealthCheckCallLogRepositoryQueryImpl.java
+++ b/src/main/java/com/pickax/status/page/server/repository/HealthCheckCallLogRepositoryQueryImpl.java
@@ -15,7 +15,6 @@ public class HealthCheckCallLogRepositoryQueryImpl implements HealthCheckCallLog
 
     private final EntityManager entityManager;
 
-
     @Override
     public List<LatestHealthCheckCallLogDto> findLatestLogsByComponentId() {
         String sql = "" +
@@ -23,7 +22,10 @@ public class HealthCheckCallLogRepositoryQueryImpl implements HealthCheckCallLog
                 "       logs.id AS healthCheckRequestLogId,\n" +
                 "       logs.component_id AS componentId,\n" +
                 "       logs.request_at AS latestRequestDate,\n" +
-                "       c.frequency AS frequency\n" +
+                "       c.frequency AS frequency,\n" +
+                "       c.component_status AS componentStatus,\n" +
+                "       c.name AS componentName,\n" +
+                "       s.name AS siteName\n" +
                 "FROM \n" +
                 "     health_check_call_logs logs,\n" +
                 "        (SELECT r.component_id, MAX(r.request_at) AS lastest_request_date\n" +
@@ -31,6 +33,7 @@ public class HealthCheckCallLogRepositoryQueryImpl implements HealthCheckCallLog
                 "         GROUP BY r.component_id\n" +
                 "         ) latest_logs\n" +
                 "     INNER JOIN components c ON c.id = latest_logs.component_id AND c.is_active = true\n" +
+                "     INNER JOIN sites s on c.site_id = s.id AND s.site_registration_status = 'COMPLETED'\n" +
                 "WHERE\n" +
                 "      logs.component_id = latest_logs.component_id\n" +
                 "      AND logs.request_at = latest_logs.lastest_request_date";

--- a/src/main/resources/templates/component_status_notification.html
+++ b/src/main/resources/templates/component_status_notification.html
@@ -48,7 +48,7 @@
                     <tr>
                         <td>
                             <h1 style="margin: 1em 0;font-size: 2em; text-align:center;">
-                                <span th:text="${component}"></span>
+                                <span th:text="${notification.siteName}"></span>-<span th:text="${notification.componentName}"></span>
                                 <br />
                                 경고/정상화 알림</h1>
                             <br>
@@ -56,9 +56,8 @@
                     </tr>
                     <tr>
                         <td>
-<!--                            <p>안녕하세요, {{name}}님</p>-->
-                            <p>안녕하세요, <span th:text="${username}"></span>님</p>
-                            <p><span th:text="${component}"></span>의 상태가 <span th:text="${previousComponentStatus}"></span>에서 <span th:text="${currentComponentStatus}"></span> 로 변경되었습니다. </p>
+                            <p>안녕하세요, <span th:text="${notification.username}"></span>님</p>
+                            <p><span th:text="${notification.componentName}"></span>의 상태가 <span th:text="${notification.previousComponentStatus}"></span>에서 <span th:text="${notification.currentComponentStatus}"></span> 로 변경되었습니다. </p>
                             <p>-Quack Run-</p>
                         </td>
 


### PR DESCRIPTION
내용
- 컴포넌트 상태가 변경되면 이메일로 알려주는 기능 
- 유저 도메인이 없으므로 유저 관련한 데이터는 null 인 상태
    - 이메일 전송 테스트를 하는 경우 EmailSender.sendComponentStatusChangedNotifyEmail 메서드의 receiverEmail 에 본인의 이메일로 변경