### PR TITLE
refactor : test.yml에서 사용하는 내용 Mock으로 대체

### DIFF
--- a/src/main/java/com/pickax/status/page/server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/pickax/status/page/server/common/exception/GlobalExceptionHandler.java
@@ -2,7 +2,7 @@ package com.pickax.status.page.server.common.exception;
 
 import com.pickax.status.page.server.common.message.LocaleMessageConverter;
 import com.pickax.status.page.server.dto.reseponse.common.ErrorResponse;
-import com.pickax.status.page.server.service.slack.SlackService;
+import com.pickax.status.page.server.service.slack.ErrorAlertService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +20,7 @@ import java.util.List;
 public class GlobalExceptionHandler {
 
 	private final LocaleMessageConverter localeMessage;
-	private final SlackService slackService;
+	private final ErrorAlertService errorAlertService;
 
 	@ExceptionHandler(value = {CustomException.class})
 	protected ResponseEntity<ErrorResponse> handleCustomException(CustomException e, HttpServletRequest request) {
@@ -49,6 +49,6 @@ public class GlobalExceptionHandler {
 	}
 
 	private void sendErrorMessageToSlack(Exception e, String message, HttpStatus httpStatus) {
-		slackService.sendErrorMessage(e, message, httpStatus);
+		errorAlertService.sendErrorMessage(e, message, httpStatus);
 	}
 }

--- a/src/main/java/com/pickax/status/page/server/service/slack/ErrorAlertService.java
+++ b/src/main/java/com/pickax/status/page/server/service/slack/ErrorAlertService.java
@@ -1,0 +1,7 @@
+package com.pickax.status.page.server.service.slack;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorAlertService {
+	void sendErrorMessage(Exception exception, String message, HttpStatus httpStatus);
+}

--- a/src/main/java/com/pickax/status/page/server/service/slack/MockErrorAlertService.java
+++ b/src/main/java/com/pickax/status/page/server/service/slack/MockErrorAlertService.java
@@ -1,0 +1,19 @@
+package com.pickax.status.page.server.service.slack;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Profile("!prod")
+@Slf4j
+public class MockErrorAlertService implements ErrorAlertService {
+	@Override
+	public void sendErrorMessage(Exception exception, String message, HttpStatus httpStatus) {
+		log.info("MockSlackServiceImpl.sendErrorMessage");
+	}
+}

--- a/src/main/java/com/pickax/status/page/server/service/slack/SlackService.java
+++ b/src/main/java/com/pickax/status/page/server/service/slack/SlackService.java
@@ -6,6 +6,7 @@ import com.slack.api.model.Attachment;
 import com.slack.api.model.block.LayoutBlock;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
@@ -14,34 +15,29 @@ import java.util.List;
 
 @Slf4j
 @Service
-public class SlackService {
-    @Value(value = "${profiles.name}")
-    String profile;
-
+@Profile("prod")
+public class SlackService implements ErrorAlertService {
     @Value(value = "${slack.token}")
     String token;
 
     @Value(value = "${slack.channel.monitor}")
     String channel;
 
-    private static final String PROD = "prod";
     private static final String PROD_ERROR_MESSAGE_TITLE = "🐤 *꽤액!!! 꽤애액!!! 에러 발생!!!*";
     private static final String CLIENT_5xx_ERROR_COLOR = "#e82415";
     private static final String CLIENT_4xx_ERROR_COLOR = "#e8bf1a";
 
     public void sendErrorMessage(Exception exception, String message, HttpStatus httpStatus) {
-        if (PROD.equals(profile)) {
-            try {
-                String color = httpStatus.is4xxClientError() ? CLIENT_4xx_ERROR_COLOR : CLIENT_5xx_ERROR_COLOR;
-                List<LayoutBlock> layoutBlocks = SlackServiceUtils.createErrorMessage(exception, message);
-                List<Attachment> attachments = SlackServiceUtils.createAttachments(color, layoutBlocks);
-                Slack.getInstance().methods(token).chatPostMessage(request ->
-                        request.channel(channel)
-                                .attachments(attachments)
-                                .text(PROD_ERROR_MESSAGE_TITLE));
-            } catch (SlackApiException | IOException e) {
-                log.error(e.getMessage(), e);
-            }
+        try {
+            String color = httpStatus.is4xxClientError() ? CLIENT_4xx_ERROR_COLOR : CLIENT_5xx_ERROR_COLOR;
+            List<LayoutBlock> layoutBlocks = SlackServiceUtils.createErrorMessage(exception, message);
+            List<Attachment> attachments = SlackServiceUtils.createAttachments(color, layoutBlocks);
+            Slack.getInstance().methods(token).chatPostMessage(request ->
+                    request.channel(channel)
+                            .attachments(attachments)
+                            .text(PROD_ERROR_MESSAGE_TITLE));
+        } catch (SlackApiException | IOException e) {
+            log.error(e.getMessage(), e);
         }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,6 +62,3 @@ slack:
   channel:
     monitor: '#error-quack-run'
 
-profiles:
-  name: ${ACTIVE_PROFILE}
-

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -33,20 +33,6 @@ spring:
         show_sql: true
     open-in-view: false
 
-  mail:
-    protocol: smtp
-    host: smtp.gmail.com
-    port: 587
-    username: sender
-    password: password
-    default-encoding: UTF-8
-    properties:
-      mail:
-        smtp:
-          starttls:
-            enable: true
-          auth: true
-
 logging:
   level:
     com.pickax.status.page.server: debug
@@ -56,10 +42,3 @@ security:
     secret: "&E)H@McQeThWmZq4t7w!z%C*F-JaNdRgUjXn2r5u8x/A?D(G+KbPeShVmYp3s6v9"
     access-token-expire: 3600000
 
-slack:
-  token: abcde
-  channel:
-    monitor: '#error-quack-run'
-
-profiles:
-  name: test


### PR DESCRIPTION
### test.yml에서 사용하는 내용 Mock으로 대체

- test.yml 에 필요하지 않은 내용 분리하였습니다
- quartz는 분리가 안되네요.. 

더 좋은 방법이 있다면 알려주세요~
